### PR TITLE
fix: kernel exits cleanly in non-interactive one-shot mode

### DIFF
--- a/agents/echo_agent.py
+++ b/agents/echo_agent.py
@@ -1,10 +1,9 @@
 from core.agent import Agent
-from core.message import Message
-import time
 
 class EchoAgent(Agent):
-    def handle_message(self, message: Message):
-        if message.type == "heartbeat":
-            self.send("heartbeat", Message("heartbeat", {"agent": "heartbeat", "timestamp": time.time()}))
-        elif message.type == "tick":
-            self.send("echo", message)
+    def __init__(self):
+        super().__init__(name="echo_agent")
+
+    def handle(self, message_type, payload):
+        if message_type == "echo":
+            print(f"[echo] {payload}")

--- a/agents/heartbeat_agent.py
+++ b/agents/heartbeat_agent.py
@@ -1,0 +1,8 @@
+from core.agent import Agent
+
+class HeartbeatAgent(Agent):
+    def __init__(self):
+        super().__init__(name="heartbeat_agent")
+
+    def handle(self, message_type, payload):
+        pass

--- a/agents/logging_agent.py
+++ b/agents/logging_agent.py
@@ -1,0 +1,8 @@
+from core.agent import Agent
+
+class LoggingAgent(Agent):
+    def __init__(self):
+        super().__init__(name="logging_agent")
+
+    def handle(self, message_type, payload):
+        pass

--- a/agents/perception_agent.py
+++ b/agents/perception_agent.py
@@ -1,0 +1,8 @@
+from core.agent import Agent
+
+class PerceptionAgent(Agent):
+    def __init__(self):
+        super().__init__(name="perception_agent")
+
+    def handle(self, message_type, payload):
+        pass

--- a/agents/scheduler_agent.py
+++ b/agents/scheduler_agent.py
@@ -1,0 +1,9 @@
+from core.agent import Agent
+
+class SchedulerAgent(Agent):
+    def __init__(self, interval=5):
+        super().__init__(name="scheduler_agent")
+        self.interval = interval
+
+    def handle(self, message_type, payload):
+        pass

--- a/core/agent_bus.py
+++ b/core/agent_bus.py
@@ -43,6 +43,11 @@ class AgentBus:
         self._tls.depth = depth + 1
         try:
             for agent in list(self._targets(message_type)):
-                agent.handle(message_type, payload)
+                try:
+                    agent.handle(message_type, payload)
+                except NotImplementedError:
+                    pass  # unimplemented stub — skip silently
+                except Exception as e:
+                    print(f"[bus] {agent.name} raised on '{message_type}': {e}")
         finally:
             self._tls.depth = depth

--- a/core/agent_bus.py
+++ b/core/agent_bus.py
@@ -15,6 +15,10 @@ class AgentBus:
         self._agents[name] = agent
         self._subscriptions[name] = set(subscriptions) if subscriptions else {'*'}
 
+    def register(self, agent, subscriptions=None):
+        """Convenience: register an agent using its .name attribute."""
+        self.register_agent(agent.name, agent, subscriptions)
+
     def register_default_agents(self):
         """Reserved for built-ins (noop for now)."""
         pass

--- a/core/consensus.py
+++ b/core/consensus.py
@@ -1,18 +1,27 @@
-import os, asyncio, raftos
+import os, asyncio
+try:
+    import raftos
+    _RAFTOS = True
+except ImportError:
+    _RAFTOS = False
 
 def _valid(addr: str) -> bool:
     return isinstance(addr, str) and ':' in addr and addr.strip()
 
-class Consensus:
+class ConsensusNode:  # alias kept for kernel import compatibility
     def __init__(self, node_id=None, peers=None):
         self.node_id = node_id or os.getenv('RAFT_ID', '')
         peers_env = os.getenv('RAFT_PEERS', '')
         self.peers = peers if peers is not None else [
             p.strip() for p in peers_env.split(',') if _valid(p)
         ]
-        raftos.configure({'log_path': f'./logs/{self.node_id or "node"}'})
+        if _RAFTOS:
+            raftos.configure({'log_path': f'./logs/{self.node_id or "node"}'})
 
     async def start(self):
+        if not _RAFTOS:
+            print("[consensus] raftos not installed — consensus disabled")
+            return
         if not _valid(self.node_id):
             print("[consensus] RAFT_ID not set as host:port; skipping consensus")
             return

--- a/core/kernel.py
+++ b/core/kernel.py
@@ -1,6 +1,8 @@
 import threading
 import time
+import signal
 import os
+import sys
 
 from core.agent_bus import AgentBus
 from core.plugin_manager import PluginManager
@@ -8,19 +10,21 @@ from core.message import Message
 from core.consensus import ConsensusNode
 from core.repl import start_repl
 
+
 class Kernel:
     def __init__(self):
-        self.bus = AgentBus()
+        self.bus     = AgentBus()
         self.plugins = PluginManager(self.bus)
+        self._stop   = threading.Event()
 
     def bootstrap(self):
         print("🚀 Bootstrapping AetherionPrime Kernel...")
 
-        # Start core agents
-        from agents.echo_agent import EchoAgent
-        from agents.logging_agent import LoggingAgent
-        from agents.heartbeat_agent import HeartbeatAgent
-        from agents.scheduler_agent import SchedulerAgent
+        # Core agents
+        from agents.echo_agent       import EchoAgent
+        from agents.logging_agent    import LoggingAgent
+        from agents.heartbeat_agent  import HeartbeatAgent
+        from agents.scheduler_agent  import SchedulerAgent
         from agents.perception_agent import PerceptionAgent
 
         self.bus.register(EchoAgent())
@@ -29,24 +33,37 @@ class Kernel:
         self.bus.register(SchedulerAgent(interval=5))
         self.bus.register(PerceptionAgent())
 
-        # Start plugin loader
-        plugin_thread = threading.Thread(target=self.plugins.load_plugins, daemon=True)
-        plugin_thread.start()
+        # Plugins — load in foreground so they're ready before we block
+        self.plugins.load_plugins()
 
-        # Start consensus if env configured
+        # Consensus (optional)
         if os.environ.get("RAFT_ID"):
             consensus = ConsensusNode()
-            consensus_thread = threading.Thread(target=consensus.run, daemon=True)
-            consensus_thread.start()
+            threading.Thread(target=consensus.run, daemon=True).start()
         else:
             print("[consensus] Not configured. Set RAFT_ID to enable.")
 
-        # Start REPL only when attached to a real terminal
-        import sys
+        # Signal handlers for clean shutdown
+        for sig in (signal.SIGTERM, signal.SIGINT):
+            signal.signal(sig, self._handle_signal)
+
+        # Interactive: hand off to REPL (blocks until user types exit)
         if sys.stdin.isatty():
             start_repl(self.bus)
         else:
-            print("[kernel] Non-interactive mode — REPL skipped. Kernel running.")
+            # Non-interactive (service / programmatic): keep process alive
+            print("[kernel] Service mode — waiting for SIGTERM/SIGINT to stop.")
+            self._stop.wait()
+            print("[kernel] Shutdown complete.")
+
+    def _handle_signal(self, signum, frame):
+        print(f"\n[kernel] Signal {signum} received — shutting down.")
+        self._stop.set()
+
+    def dispatch(self, message_type: str, payload):
+        """Convenience wrapper for external callers."""
+        self.bus.dispatch(message_type, payload)
+
 
 if __name__ == "__main__":
     Kernel().bootstrap()

--- a/core/kernel.py
+++ b/core/kernel.py
@@ -50,11 +50,14 @@ class Kernel:
         # Interactive: hand off to REPL (blocks until user types exit)
         if sys.stdin.isatty():
             start_repl(self.bus)
-        else:
-            # Non-interactive (service / programmatic): keep process alive
+        elif os.environ.get("AETHER_SERVICE"):
+            # Explicit long-running service mode: block until signal
             print("[kernel] Service mode — waiting for SIGTERM/SIGINT to stop.")
             self._stop.wait()
             print("[kernel] Shutdown complete.")
+        else:
+            # Non-interactive one-shot (import, test, pipeline dispatch): return immediately
+            print("[kernel] Ready.")
 
     def _handle_signal(self, signum, frame):
         print(f"\n[kernel] Signal {signum} received — shutting down.")

--- a/core/kernel.py
+++ b/core/kernel.py
@@ -35,17 +35,18 @@ class Kernel:
 
         # Start consensus if env configured
         if os.environ.get("RAFT_ID"):
-            node_id = os.environ["RAFT_ID"]
-            peers = os.environ.get("RAFT_PEERS", "")
-            peers = peers.split(",") if peers else []
-            consensus = ConsensusNode(self.bus, node_id, peers)
+            consensus = ConsensusNode()
             consensus_thread = threading.Thread(target=consensus.run, daemon=True)
             consensus_thread.start()
         else:
             print("[consensus] Not configured. Set RAFT_ID to enable.")
 
-        # Start REPL (interactive shell)
-        start_repl(self.bus)
+        # Start REPL only when attached to a real terminal
+        import sys
+        if sys.stdin.isatty():
+            start_repl(self.bus)
+        else:
+            print("[kernel] Non-interactive mode — REPL skipped. Kernel running.")
 
 if __name__ == "__main__":
     Kernel().bootstrap()

--- a/core/plugin_manager.py
+++ b/core/plugin_manager.py
@@ -10,9 +10,16 @@ class PluginManager:
         self.bus = bus
 
     def load_plugins(self):
-        for fname in os.listdir('plugins'):
-            if fname.endswith('.py') and fname != '__init__.py':
-                mod_name = f"plugins.{fname[:-3]}"
+        plugin_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'plugins')
+        if not os.path.isdir(plugin_dir):
+            return
+        for fname in sorted(os.listdir(plugin_dir)):
+            if not fname.endswith('.py') or fname == '__init__.py':
+                continue
+            mod_name = f"plugins.{fname[:-3]}"
+            try:
                 module = importlib.import_module(mod_name)
                 if hasattr(module, 'register'):
                     module.register(self.bus)
+            except Exception as e:
+                print(f"[plugin_manager] skipped {fname}: {e}")

--- a/plugins/agentai_bridge_plugin.py
+++ b/plugins/agentai_bridge_plugin.py
@@ -1,0 +1,92 @@
+"""
+AgentAI Bridge Plugin — connects AetherionGenesis kernel to AgentAI's 3-tier
+model router and Nexus Trinity 7-gate pipeline.
+
+Message types dispatched:
+  agentai.complete   payload: {agent_id, prompt, system, gate, think, code}
+                     → routes to correct Ollama tier via model_router
+  agentai.gate       payload: {gate_num, hypothesis, contract, context}
+                     → runs a single Nexus Trinity gate
+  agentai.pipeline   payload: {hypothesis, contract}
+                     → runs the full 7-gate pipeline
+
+Message types emitted:
+  agentai.result     payload: {agent_id, result, tier}
+  agentai.finding    payload: {finding dict from gate output}
+  agentai.error      payload: {agent_id, error}
+"""
+
+import sys
+import os
+
+# Add AgentAI to path
+_AGENTAI_PATH = os.path.expanduser("~/AgentAI")
+if _AGENTAI_PATH not in sys.path:
+    sys.path.insert(0, _AGENTAI_PATH)
+
+from core.agent import Agent
+
+
+class AgentAIBridgeAgent(Agent):
+    def __init__(self):
+        super().__init__(name="agentai_bridge")
+        self._router = None
+        self._pipeline = None
+
+    def _get_router(self):
+        if self._router is None:
+            try:
+                from core.model_router import ModelRouter
+                self._router = ModelRouter()
+            except Exception as e:
+                print(f"[agentai_bridge] model_router unavailable: {e}")
+        return self._router
+
+    def _get_pipeline(self):
+        if self._pipeline is None:
+            try:
+                from core.gates.verification_loop import VerificationLoop
+                self._pipeline = VerificationLoop()
+            except Exception as e:
+                print(f"[agentai_bridge] pipeline unavailable: {e}")
+        return self._pipeline
+
+    def handle(self, message_type, payload):
+        if message_type == "agentai.complete":
+            self._handle_complete(payload)
+        elif message_type == "agentai.gate":
+            self._handle_gate(payload)
+        elif message_type == "agentai.pipeline":
+            self._handle_pipeline(payload)
+
+    def _handle_complete(self, payload):
+        router = self._get_router()
+        if not router:
+            return
+        try:
+            agent_id = payload.get("agent_id", "unknown")
+            result = router.complete(
+                prompt=payload.get("prompt", ""),
+                system=payload.get("system"),
+                gate=payload.get("gate"),
+                think=payload.get("think", False),
+                code=payload.get("code", False),
+                agent_id=agent_id,
+            )
+            from core.agent_bus import AgentBus
+            tier = router.agent_tier(agent_id) if hasattr(router, "agent_tier") else "?"
+            print(f"[agentai_bridge] {agent_id} (tier {tier}) → {len(result)} chars")
+        except Exception as e:
+            print(f"[agentai_bridge] complete error: {e}")
+
+    def _handle_gate(self, payload):
+        print(f"[agentai_bridge] gate {payload.get('gate_num')} → {payload.get('hypothesis', '')[:60]}")
+
+    def _handle_pipeline(self, payload):
+        print(f"[agentai_bridge] pipeline → {payload.get('hypothesis', '')[:80]}")
+
+
+def register(bus):
+    agent = AgentAIBridgeAgent()
+    bus.register(agent, subscriptions={"agentai.complete", "agentai.gate", "agentai.pipeline"})
+    print("[plugin] agentai_bridge registered")

--- a/plugins/agentai_bridge_plugin.py
+++ b/plugins/agentai_bridge_plugin.py
@@ -1,25 +1,19 @@
 """
 AgentAI Bridge Plugin — connects AetherionGenesis kernel to AgentAI's 3-tier
-model router and Nexus Trinity 7-gate pipeline.
+model router. Exposes the router as a bus-addressable service so any agent
+can request LLM completions without importing model_router directly.
 
-Message types dispatched:
-  agentai.complete   payload: {agent_id, prompt, system, gate, think, code}
-                     → routes to correct Ollama tier via model_router
-  agentai.gate       payload: {gate_num, hypothesis, contract, context}
-                     → runs a single Nexus Trinity gate
-  agentai.pipeline   payload: {hypothesis, contract}
-                     → runs the full 7-gate pipeline
+Bus messages handled:
+  agentai.complete  {agent_id, prompt, system, gate, think, code, max_tokens}
+                    → routes via model_router.complete(), emits agentai.result
 
-Message types emitted:
-  agentai.result     payload: {agent_id, result, tier}
-  agentai.finding    payload: {finding dict from gate output}
-  agentai.error      payload: {agent_id, error}
+Bus messages emitted:
+  agentai.result  {agent_id, result, tier, route}
+  agentai.error   {agent_id, error}
 """
 
-import sys
-import os
+import sys, os, threading
 
-# Add AgentAI to path
 _AGENTAI_PATH = os.path.expanduser("~/AgentAI")
 if _AGENTAI_PATH not in sys.path:
     sys.path.insert(0, _AGENTAI_PATH)
@@ -28,65 +22,68 @@ from core.agent import Agent
 
 
 class AgentAIBridgeAgent(Agent):
-    def __init__(self):
+    def __init__(self, bus):
         super().__init__(name="agentai_bridge")
+        self._bus    = bus
         self._router = None
-        self._pipeline = None
 
     def _get_router(self):
         if self._router is None:
             try:
-                from core.model_router import ModelRouter
+                from core.model_router import ModelRouter, agent_tier
                 self._router = ModelRouter()
+                self._agent_tier = agent_tier
             except Exception as e:
                 print(f"[agentai_bridge] model_router unavailable: {e}")
         return self._router
 
-    def _get_pipeline(self):
-        if self._pipeline is None:
-            try:
-                from core.gates.verification_loop import VerificationLoop
-                self._pipeline = VerificationLoop()
-            except Exception as e:
-                print(f"[agentai_bridge] pipeline unavailable: {e}")
-        return self._pipeline
-
     def handle(self, message_type, payload):
         if message_type == "agentai.complete":
-            self._handle_complete(payload)
-        elif message_type == "agentai.gate":
-            self._handle_gate(payload)
-        elif message_type == "agentai.pipeline":
-            self._handle_pipeline(payload)
+            # Run in thread — model calls block
+            threading.Thread(target=self._handle_complete, args=(payload,), daemon=True).start()
 
     def _handle_complete(self, payload):
         router = self._get_router()
         if not router:
+            self._bus.dispatch("agentai.error", {
+                "agent_id": payload.get("agent_id", "?"),
+                "error": "model_router not available",
+            })
             return
+
+        agent_id   = payload.get("agent_id", "")
+        prompt     = payload.get("prompt", "")
+        system     = payload.get("system")
+        gate       = payload.get("gate")
+        think      = payload.get("think", False)
+        code       = payload.get("code", False)
+        max_tokens = payload.get("max_tokens", 4096)
+
         try:
-            agent_id = payload.get("agent_id", "unknown")
             result = router.complete(
-                prompt=payload.get("prompt", ""),
-                system=payload.get("system"),
-                gate=payload.get("gate"),
-                think=payload.get("think", False),
-                code=payload.get("code", False),
-                agent_id=agent_id,
+                prompt=prompt,
+                system=system,
+                gate=gate,
+                max_tokens=max_tokens,
+                think=think,
+                code=code,
+                agent_id=agent_id or None,
             )
-            from core.agent_bus import AgentBus
-            tier = router.agent_tier(agent_id) if hasattr(router, "agent_tier") else "?"
-            print(f"[agentai_bridge] {agent_id} (tier {tier}) → {len(result)} chars")
+            tier  = self._agent_tier(agent_id) if agent_id and hasattr(self, "_agent_tier") else "?"
+            route = getattr(router, "_last_route", "?")
+            print(f"[agentai_bridge] {agent_id or 'anon'} tier={tier} route={route} → {len(result)} chars")
+            self._bus.dispatch("agentai.result", {
+                "agent_id": agent_id,
+                "result":   result,
+                "tier":     tier,
+                "route":    route,
+            })
         except Exception as e:
-            print(f"[agentai_bridge] complete error: {e}")
-
-    def _handle_gate(self, payload):
-        print(f"[agentai_bridge] gate {payload.get('gate_num')} → {payload.get('hypothesis', '')[:60]}")
-
-    def _handle_pipeline(self, payload):
-        print(f"[agentai_bridge] pipeline → {payload.get('hypothesis', '')[:80]}")
+            print(f"[agentai_bridge] complete error ({agent_id}): {e}")
+            self._bus.dispatch("agentai.error", {"agent_id": agent_id, "error": str(e)})
 
 
 def register(bus):
-    agent = AgentAIBridgeAgent()
-    bus.register(agent, subscriptions={"agentai.complete", "agentai.gate", "agentai.pipeline"})
+    agent = AgentAIBridgeAgent(bus)
+    bus.register(agent, subscriptions={"agentai.complete"})
     print("[plugin] agentai_bridge registered")

--- a/plugins/nexus_trinity_plugin.py
+++ b/plugins/nexus_trinity_plugin.py
@@ -1,115 +1,396 @@
 """
-Nexus Trinity Plugin — exposes the 7-gate vulnerability verification pipeline
-as AgentBus message handlers.
+Nexus Trinity Plugin — 7-gate vulnerability verification pipeline wired to
+AgentAI's model_router for real LLM execution.
 
-Message types handled:
-  nexus.hypothesis   payload: {hypothesis, contract_path, context}
-                     → runs Gate 1 (hypothesis formation)
-  nexus.pipeline     payload: {hypothesis, contract_path, context, gates}
-                     → runs specified gates (default: all 7)
-  nexus.gate         payload: {gate_num, hypothesis, evidence, context}
-                     → runs a single numbered gate
+Bus messages handled:
+  nexus.hypothesis  {hypothesis, contract_path, code}
+  nexus.pipeline    {hypothesis, contract_path, code, gates=[1..7]}
+  nexus.gate        {gate_num, hypothesis, evidence, poc, context}
 
-Message types emitted:
-  nexus.gate_result  payload: {gate_num, passed, evidence, notes}
-  nexus.finding      payload: {severity, title, description, poc, gates_passed}
-  nexus.rejected     payload: {hypothesis, kill_pattern, reason}
-
-Kill patterns (from cantina_submission_lessons.md):
-  1. Flash Accounting Net-Zero — delta accumulates, unlock() enforces net-zero
-  2. assertTrue(true) PoC — not a real exploit
-  3. hex"" Signature PoC — empty sig ≠ bypass
-  4. Privileged Role Out of Scope — operator/admin calls excluded
-  5. Documented Known Constraint — acknowledged in docs
-  6. Custom Simulation PoC — not a fork test against deployed state
+Bus messages emitted:
+  nexus.gate_result  {gate_num, name, passed, output, kill_reason}
+  nexus.finding      {severity, title, hypothesis, evidence, poc, gates_passed, economic}
+  nexus.rejected     {hypothesis, gate, kill_pattern, reason}
 """
 
-import os
-import sys
+import sys, os, json, traceback, threading
+
+_AGENTAI_PATH = os.path.expanduser("~/AgentAI")
+if _AGENTAI_PATH not in sys.path:
+    sys.path.insert(0, _AGENTAI_PATH)
 
 from core.agent import Agent
 
+# ── Kill pattern definitions ──────────────────────────────────────────────────
 _KILL_PATTERNS = {
-    1: "Flash Accounting Net-Zero — _accountDelta accumulates, unlock() enforces net-zero exit",
-    2: "assertTrue(true) PoC — PoC proves nothing without an assertion that can fail",
-    3: "hex\"\" Signature PoC — empty calldata is not a signature bypass on guarded functions",
-    4: "Privileged Role Out of Scope — operator/admin/owner-initiated paths excluded by scope",
-    5: "Documented Known Constraint — team explicitly acknowledges this behavior in docs",
-    6: "Custom Simulation PoC — only fork tests against deployed state are accepted",
+    1: "Flash Accounting Net-Zero: _accountDelta accumulates, unlock() enforces net-zero exit — nested multi-pool ops are the intended model, not a bug",
+    2: "assertTrue(true) PoC: assertion can never fail regardless of protocol state — proves nothing",
+    3: 'hex"" Signature PoC: empty calldata is not a signature bypass on guarded entry points',
+    4: "Privileged Role Out of Scope: operator/admin/owner-initiated paths are excluded by scope rules",
+    5: "Documented Known Constraint: team explicitly acknowledges this edge case in docs/comments",
+    6: "Custom Simulation PoC: only fork tests against live deployed state are accepted — no mocked environments",
 }
 
-_GATES = [
-    "Hypothesis Formation",
-    "Evidence Gathering",
-    "Simulation / PoC",
-    "Historical Replay",
-    "Economic Impact",
-    "Adversarial Challenge",
-    "Reproducibility",
-]
+# ── Gate definitions: (name, tier, system_prompt) ────────────────────────────
+_GATES = {
+    1: (
+        "Hypothesis Formation",
+        1,  # Tier 1 — reasoning
+        """You are a senior DeFi security researcher forming vulnerability hypotheses.
+Rules:
+- Output ONE specific, falsifiable hypothesis naming: exact function, exact state change, exact attacker action.
+- If nothing clearly wrong: respond with exactly "NO_HYPOTHESIS".
+- Never be vague. "reentrancy exists" is not a hypothesis. "attacker calls withdraw() via fallback during _transfer(), draining vault before balances update" IS.
+- Check kill patterns before hypothesizing:
+  * Flash accounting net-zero: accumulation IS the design, unlock() enforces settlement.
+  * Empty sig / hex"": not a bypass.
+  * Admin/operator paths: out of scope.
+  * Documented constraints: not bugs.""",
+    ),
+    2: (
+        "Evidence Gathering",
+        3,  # Tier 3 — parser (JSON output)
+        """You are a code evidence extractor. Output ONLY valid JSON, no prose, no markdown fences.
+Schema: {"lines": [{"file": "<str>", "line": <int>, "content": "<str>", "relevance": "<str>"}], "supports_hypothesis": <bool>, "missing_guards": ["<str>"], "kill_pattern_hit": <null|int>}
+- kill_pattern_hit: 1=flash-accounting, 2=asserttrue, 3=empty-sig, 4=privileged-oos, 5=documented, 6=custom-sim. null if none.""",
+    ),
+    3: (
+        "Simulation / PoC",
+        2,  # Tier 2 — execution/code
+        """You are a Foundry exploit developer. Write a complete Foundry fork test.
+Rules — violation = automatic kill:
+1. Fork mainnet (or target chain) at a specific recent block number.
+2. Use real deployed contract addresses — no mocks, no custom deployments.
+3. Assertion MUST be able to fail: vm.assertGt(stolen, 0) or vm.assertEq(balance, 0). Never assertTrue(true).
+4. Include exact forge command to run it.
+5. If hypothesis is not exploitable via fork test: say "UNEXPLOITABLE: <reason>".
+
+Template:
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+import "forge-std/Test.sol";
+
+contract ExploitTest is Test {
+    function setUp() public {
+        vm.createFork("mainnet", <BLOCK>);
+    }
+    function test_exploit() public {
+        // setup attacker
+        // execute attack
+        assertGt(address(attacker).balance, 0, "exploit failed");
+    }
+}""",
+    ),
+    4: (
+        "Historical Replay",
+        2,  # Tier 2 — execution
+        """You are a DeFi exploit historian with knowledge of DeFiHackLabs (740+ incidents) and Rekt.news.
+Given a vulnerability pattern, find matching historical exploits.
+Output JSON: {"matches": [{"protocol": str, "date": str, "loss_usd": int, "vector": str, "similarity": "exact|similar|related"}], "novel": bool}
+- novel: true if no close historical match found.""",
+    ),
+    5: (
+        "Economic Impact",
+        1,  # Tier 1 — reasoning
+        """You are a DeFi economic security analyst.
+Model the maximum extractable value (MEV) from this vulnerability.
+Output JSON: {
+  "max_value_usd": <int>,
+  "tvl_at_risk": <int>,
+  "gas_cost_estimate": <int>,
+  "flash_loan_fee": <float>,
+  "profitable": <bool>,
+  "severity": "Critical|High|Medium|Low",
+  "severity_rationale": "<str>",
+  "attack_scenarios": [{"label": str, "value_usd": int, "steps": int}]
+}
+Severity thresholds: Critical >$500k, High $50k-$500k, Medium $5k-$50k, Low <$5k.""",
+    ),
+    6: (
+        "Adversarial Challenge",
+        1,  # Tier 1 — reasoning
+        """You are a hostile senior auditor paid $10,000 to REJECT this finding.
+Your job: find every reason it fails.
+Check:
+- Missing preconditions the attacker cannot meet
+- Access controls blocking the attack path
+- Protocol invariants that prevent the exploit
+- Economic barriers (gas > profit, slippage, MEV competition)
+- Kill patterns: flash accounting net-zero, assertTrue(true), hex"" sig, privileged oos, documented constraint, custom simulation
+If you find a fatal flaw: "REJECTED: <specific reason>"
+If you CANNOT refute it after exhaustive challenge: "FINDING_STANDS: <remaining concerns if any>" """,
+    ),
+    7: (
+        "Reproducibility",
+        2,  # Tier 2 — execution
+        """You are a Foundry CI engineer verifying a PoC is reproducible.
+Check:
+1. Complete Foundry test (SPDX, pragma, imports, contract, setUp, test function)?
+2. Correct fork setup with block number?
+3. Real deployed addresses (not address(0) or placeholders)?
+4. Assertion that can actually fail?
+5. forge command included?
+Output JSON: {"reproducible": bool, "score": <0-100>, "issues": ["<str>"], "forge_command": "<str>", "verdict": "PASS|FAIL"}""",
+    ),
+}
+
+
+def _kill_pattern_fast(text: str) -> int | None:
+    t = text.lower()
+    if ("flash" in t or "unlock" in t or "delta" in t) and ("net-zero" in t or "accumulate" in t or "accounting" in t):
+        return 1
+    if "asserttrue(true)" in t or "assert(true)" in t:
+        return 2
+    if 'hex""' in t or "empty signature" in t or "empty calldata" in t:
+        return 3
+    if any(p in t for p in ["admin only", "onlyowner", "privileged"]) and "scope" in t:
+        return 4
+    if "known" in t and ("documented" in t or "acknowledged" in t or "intended" in t):
+        return 5
+    if "custom simulation" in t or ("mock" in t and "poc" in t):
+        return 6
+    return None
 
 
 class NexusTrinityAgent(Agent):
-    def __init__(self):
+    def __init__(self, bus):
         super().__init__(name="nexus_trinity")
+        self._bus = bus
+        self._router = None
+
+    def _get_router(self):
+        if self._router is None:
+            try:
+                from core.model_router import ModelRouter
+                self._router = ModelRouter()
+            except Exception as e:
+                print(f"[nexus] model_router unavailable: {e}")
+        return self._router
 
     def handle(self, message_type, payload):
         if message_type == "nexus.hypothesis":
-            self._run_hypothesis(payload)
+            threading.Thread(target=self._run_hypothesis, args=(payload,), daemon=True).start()
         elif message_type == "nexus.pipeline":
-            self._run_pipeline(payload)
+            threading.Thread(target=self._run_pipeline, args=(payload,), daemon=True).start()
         elif message_type == "nexus.gate":
-            self._run_single_gate(payload)
+            threading.Thread(target=self._run_single_gate, args=(payload,), daemon=True).start()
+
+    # ── Public entry points ───────────────────────────────────────────────────
 
     def _run_hypothesis(self, payload):
         hypothesis = payload.get("hypothesis", "")
-        contract = payload.get("contract_path", "")
-        print(f"[nexus] Gate 1 — Hypothesis: {hypothesis[:80]}")
-        print(f"[nexus] Target: {contract}")
-        self._kill_pattern_check(hypothesis)
+        contract   = payload.get("contract_path", "")
+        code       = payload.get("code", "")
+        print(f"\n[nexus] Gate 1 — Hypothesis: {hypothesis[:80]}")
+        result = self._run_gate(1, hypothesis=hypothesis, contract=contract, code=code)
+        self._bus.dispatch("nexus.gate_result", result)
 
     def _run_pipeline(self, payload):
         hypothesis = payload.get("hypothesis", "")
-        contract = payload.get("contract_path", "")
-        gates = payload.get("gates", list(range(1, 8)))
-        print(f"\n[nexus] 7-gate pipeline starting")
-        print(f"[nexus] Hypothesis: {hypothesis}")
-        print(f"[nexus] Contract:   {contract}")
-        print(f"[nexus] Running gates: {gates}")
+        contract   = payload.get("contract_path", "")
+        code       = payload.get("code", "")
+        gates      = payload.get("gates", list(range(1, 8)))
 
-        kill = self._kill_pattern_check(hypothesis)
-        if kill:
-            print(f"[nexus] REJECTED — kill pattern {kill}: {_KILL_PATTERNS[kill]}")
+        print(f"\n[nexus] ══ 7-GATE PIPELINE ══")
+        print(f"[nexus] Hypothesis : {hypothesis}")
+        print(f"[nexus] Contract   : {contract}")
+
+        # Fast pre-check
+        kp = _kill_pattern_fast(hypothesis)
+        if kp:
+            reason = _KILL_PATTERNS[kp]
+            print(f"[nexus] FAST-KILL pattern {kp}: {reason}")
+            self._bus.dispatch("nexus.rejected", {"hypothesis": hypothesis, "gate": 0, "kill_pattern": kp, "reason": reason})
             return
 
+        evidence = {}
+        poc = ""
+
         for gate_num in gates:
-            name = _GATES[gate_num - 1] if gate_num <= len(_GATES) else f"Gate {gate_num}"
-            print(f"[nexus] Gate {gate_num} ({name}) — PENDING (wire to SCOUT for execution)")
+            if gate_num not in _GATES:
+                continue
+            name = _GATES[gate_num][0]
+            print(f"[nexus] ── Gate {gate_num}: {name}")
+
+            result = self._run_gate(
+                gate_num,
+                hypothesis=hypothesis,
+                contract=contract,
+                code=code,
+                evidence=evidence,
+                poc=poc,
+            )
+            self._bus.dispatch("nexus.gate_result", result)
+
+            # Accumulate evidence
+            if gate_num == 2 and result.get("output"):
+                evidence = result["output"]
+            if gate_num == 3 and result.get("output"):
+                poc = result["output"] if isinstance(result["output"], str) else str(result["output"])
+
+            # Gate kill
+            if result.get("kill_reason"):
+                print(f"[nexus] KILLED at gate {gate_num}: {result['kill_reason']}")
+                self._bus.dispatch("nexus.rejected", {
+                    "hypothesis": hypothesis,
+                    "gate": gate_num,
+                    "kill_pattern": result.get("kill_pattern"),
+                    "reason": result["kill_reason"],
+                })
+                return
+
+            # Gate 3: if UNEXPLOITABLE bail
+            if gate_num == 3 and isinstance(poc, str) and "UNEXPLOITABLE" in poc:
+                self._bus.dispatch("nexus.rejected", {
+                    "hypothesis": hypothesis,
+                    "gate": 3,
+                    "kill_pattern": None,
+                    "reason": poc,
+                })
+                return
+
+            # Gate 6: adversarial verdict
+            if gate_num == 6:
+                raw = result.get("raw_output", "")
+                if "REJECTED" in raw.upper():
+                    print(f"[nexus] Gate 6 adversarial rejection: {raw[:200]}")
+                    self._bus.dispatch("nexus.rejected", {
+                        "hypothesis": hypothesis,
+                        "gate": 6,
+                        "kill_pattern": None,
+                        "reason": raw,
+                    })
+                    return
+
+            # Gate 7: reproducibility verdict
+            if gate_num == 7:
+                out = result.get("output", {})
+                if isinstance(out, dict) and out.get("verdict") == "FAIL":
+                    print(f"[nexus] Gate 7 reproducibility failed: {out.get('issues')}")
+                    self._bus.dispatch("nexus.rejected", {
+                        "hypothesis": hypothesis,
+                        "gate": 7,
+                        "kill_pattern": None,
+                        "reason": f"PoC not reproducible: {out.get('issues', [])}",
+                    })
+                    return
+
+        # All gates passed — emit finding
+        economic = evidence.get("economic", {}) if isinstance(evidence, dict) else {}
+        severity = economic.get("severity", "High") if isinstance(economic, dict) else "High"
+        print(f"\n[nexus] ✅ FINDING CONFIRMED — {severity}")
+        self._bus.dispatch("nexus.finding", {
+            "severity":    severity,
+            "title":       hypothesis[:120],
+            "hypothesis":  hypothesis,
+            "evidence":    evidence,
+            "poc":         poc,
+            "gates_passed": gates,
+            "economic":   economic,
+        })
 
     def _run_single_gate(self, payload):
-        gate_num = payload.get("gate_num", 0)
+        gate_num   = payload.get("gate_num", 1)
         hypothesis = payload.get("hypothesis", "")
-        name = _GATES[gate_num - 1] if 1 <= gate_num <= len(_GATES) else f"Gate {gate_num}"
-        print(f"[nexus] Gate {gate_num} ({name}): {hypothesis[:80]}")
+        evidence   = payload.get("evidence", {})
+        poc        = payload.get("poc", "")
+        contract   = payload.get("contract_path", "")
+        code       = payload.get("code", "")
+        result = self._run_gate(gate_num, hypothesis=hypothesis, contract=contract,
+                                code=code, evidence=evidence, poc=poc)
+        self._bus.dispatch("nexus.gate_result", result)
 
-    def _kill_pattern_check(self, hypothesis: str) -> int | None:
-        h = hypothesis.lower()
-        if "flash" in h and ("net-zero" in h or "delta" in h or "accounting" in h):
-            return 1
-        if "asserttrue" in h or "assert(true)" in h:
-            return 2
-        if 'hex""' in h or "empty signature" in h or "empty calldata" in h:
-            return 3
-        if any(p in h for p in ["admin", "operator", "owner"]) and "out of scope" in h:
-            return 4
-        if "known" in h and ("documented" in h or "acknowledged" in h):
-            return 5
-        if "simulation" in h and "custom" in h:
-            return 6
-        return None
+    # ── Core gate runner ─────────────────────────────────────────────────────
+
+    def _run_gate(self, gate_num: int, *, hypothesis="", contract="", code="",
+                  evidence=None, poc="") -> dict:
+        router = self._get_router()
+        gate_name, tier, system_prompt = _GATES[gate_num]
+
+        user_prompt = self._build_prompt(gate_num, hypothesis=hypothesis,
+                                         contract=contract, code=code,
+                                         evidence=evidence, poc=poc)
+
+        raw_output = ""
+        parsed_output = None
+        kill_reason = None
+        kill_pattern = None
+
+        if router:
+            try:
+                raw_output = router.complete(
+                    prompt=user_prompt,
+                    system=system_prompt,
+                    gate=gate_num,
+                    think=(tier == 1),
+                    code=(tier == 2),
+                )
+                parsed_output = self._parse_output(gate_num, raw_output)
+
+                # Check for kill signal in output
+                kp = _kill_pattern_fast(raw_output)
+                if kp:
+                    kill_pattern = kp
+                    kill_reason = _KILL_PATTERNS[kp]
+
+            except Exception as e:
+                raw_output = f"ERROR: {e}"
+                print(f"[nexus] gate {gate_num} error: {e}")
+        else:
+            raw_output = "[model_router unavailable — skipped]"
+
+        result = {
+            "gate_num":    gate_num,
+            "name":        gate_name,
+            "tier":        tier,
+            "passed":      kill_reason is None and "ERROR" not in raw_output,
+            "output":      parsed_output if parsed_output is not None else raw_output,
+            "raw_output":  raw_output,
+            "kill_reason": kill_reason,
+            "kill_pattern": kill_pattern,
+        }
+        print(f"[nexus]   Gate {gate_num} {'✓' if result['passed'] else '✗'} — {len(raw_output)} chars")
+        return result
+
+    def _build_prompt(self, gate_num: int, *, hypothesis, contract, code, evidence, poc) -> str:
+        ev_str  = json.dumps(evidence, indent=2) if isinstance(evidence, dict) else str(evidence or "")
+        kp_str  = "\n".join(f"  {k}. {v}" for k, v in _KILL_PATTERNS.items())
+
+        if gate_num == 1:
+            return f"Contract: {contract}\n\nCode:\n{code[:6000]}\n\nForm a specific vulnerability hypothesis."
+        if gate_num == 2:
+            return f"Hypothesis: {hypothesis}\n\nContract: {contract}\n\nCode:\n{code[:6000]}"
+        if gate_num == 3:
+            return f"Hypothesis: {hypothesis}\n\nEvidence:\n{ev_str}\n\nContract: {contract}\n\nWrite the Foundry fork PoC."
+        if gate_num == 4:
+            return f"Vulnerability pattern: {hypothesis}\n\nFind matching historical DeFi exploits."
+        if gate_num == 5:
+            return f"Hypothesis: {hypothesis}\n\nEvidence:\n{ev_str}\n\nPoC sketch:\n{poc[:2000]}\n\nModel economic impact."
+        if gate_num == 6:
+            return (
+                f"Hypothesis: {hypothesis}\n\nEvidence:\n{ev_str}\n\nPoC:\n{poc[:2000]}\n\n"
+                f"Kill patterns to check:\n{kp_str}\n\nChallenge this finding — find every reason to reject it."
+            )
+        if gate_num == 7:
+            return f"PoC to verify:\n\n{poc}\n\nVerify reproducibility and output JSON verdict."
+        return hypothesis
+
+    def _parse_output(self, gate_num: int, raw: str):
+        if gate_num in (2, 4, 5, 7):
+            # Expect JSON
+            try:
+                # Strip markdown fences if present
+                text = raw.strip()
+                if text.startswith("```"):
+                    text = "\n".join(text.split("\n")[1:])
+                    text = text.rsplit("```", 1)[0].strip()
+                return json.loads(text)
+            except Exception:
+                return raw
+        return raw
 
 
 def register(bus):
-    agent = NexusTrinityAgent()
+    agent = NexusTrinityAgent(bus)
     bus.register(agent, subscriptions={"nexus.hypothesis", "nexus.pipeline", "nexus.gate"})
     print("[plugin] nexus_trinity registered")

--- a/plugins/nexus_trinity_plugin.py
+++ b/plugins/nexus_trinity_plugin.py
@@ -1,0 +1,115 @@
+"""
+Nexus Trinity Plugin — exposes the 7-gate vulnerability verification pipeline
+as AgentBus message handlers.
+
+Message types handled:
+  nexus.hypothesis   payload: {hypothesis, contract_path, context}
+                     → runs Gate 1 (hypothesis formation)
+  nexus.pipeline     payload: {hypothesis, contract_path, context, gates}
+                     → runs specified gates (default: all 7)
+  nexus.gate         payload: {gate_num, hypothesis, evidence, context}
+                     → runs a single numbered gate
+
+Message types emitted:
+  nexus.gate_result  payload: {gate_num, passed, evidence, notes}
+  nexus.finding      payload: {severity, title, description, poc, gates_passed}
+  nexus.rejected     payload: {hypothesis, kill_pattern, reason}
+
+Kill patterns (from cantina_submission_lessons.md):
+  1. Flash Accounting Net-Zero — delta accumulates, unlock() enforces net-zero
+  2. assertTrue(true) PoC — not a real exploit
+  3. hex"" Signature PoC — empty sig ≠ bypass
+  4. Privileged Role Out of Scope — operator/admin calls excluded
+  5. Documented Known Constraint — acknowledged in docs
+  6. Custom Simulation PoC — not a fork test against deployed state
+"""
+
+import os
+import sys
+
+from core.agent import Agent
+
+_KILL_PATTERNS = {
+    1: "Flash Accounting Net-Zero — _accountDelta accumulates, unlock() enforces net-zero exit",
+    2: "assertTrue(true) PoC — PoC proves nothing without an assertion that can fail",
+    3: "hex\"\" Signature PoC — empty calldata is not a signature bypass on guarded functions",
+    4: "Privileged Role Out of Scope — operator/admin/owner-initiated paths excluded by scope",
+    5: "Documented Known Constraint — team explicitly acknowledges this behavior in docs",
+    6: "Custom Simulation PoC — only fork tests against deployed state are accepted",
+}
+
+_GATES = [
+    "Hypothesis Formation",
+    "Evidence Gathering",
+    "Simulation / PoC",
+    "Historical Replay",
+    "Economic Impact",
+    "Adversarial Challenge",
+    "Reproducibility",
+]
+
+
+class NexusTrinityAgent(Agent):
+    def __init__(self):
+        super().__init__(name="nexus_trinity")
+
+    def handle(self, message_type, payload):
+        if message_type == "nexus.hypothesis":
+            self._run_hypothesis(payload)
+        elif message_type == "nexus.pipeline":
+            self._run_pipeline(payload)
+        elif message_type == "nexus.gate":
+            self._run_single_gate(payload)
+
+    def _run_hypothesis(self, payload):
+        hypothesis = payload.get("hypothesis", "")
+        contract = payload.get("contract_path", "")
+        print(f"[nexus] Gate 1 — Hypothesis: {hypothesis[:80]}")
+        print(f"[nexus] Target: {contract}")
+        self._kill_pattern_check(hypothesis)
+
+    def _run_pipeline(self, payload):
+        hypothesis = payload.get("hypothesis", "")
+        contract = payload.get("contract_path", "")
+        gates = payload.get("gates", list(range(1, 8)))
+        print(f"\n[nexus] 7-gate pipeline starting")
+        print(f"[nexus] Hypothesis: {hypothesis}")
+        print(f"[nexus] Contract:   {contract}")
+        print(f"[nexus] Running gates: {gates}")
+
+        kill = self._kill_pattern_check(hypothesis)
+        if kill:
+            print(f"[nexus] REJECTED — kill pattern {kill}: {_KILL_PATTERNS[kill]}")
+            return
+
+        for gate_num in gates:
+            name = _GATES[gate_num - 1] if gate_num <= len(_GATES) else f"Gate {gate_num}"
+            print(f"[nexus] Gate {gate_num} ({name}) — PENDING (wire to SCOUT for execution)")
+
+    def _run_single_gate(self, payload):
+        gate_num = payload.get("gate_num", 0)
+        hypothesis = payload.get("hypothesis", "")
+        name = _GATES[gate_num - 1] if 1 <= gate_num <= len(_GATES) else f"Gate {gate_num}"
+        print(f"[nexus] Gate {gate_num} ({name}): {hypothesis[:80]}")
+
+    def _kill_pattern_check(self, hypothesis: str) -> int | None:
+        h = hypothesis.lower()
+        if "flash" in h and ("net-zero" in h or "delta" in h or "accounting" in h):
+            return 1
+        if "asserttrue" in h or "assert(true)" in h:
+            return 2
+        if 'hex""' in h or "empty signature" in h or "empty calldata" in h:
+            return 3
+        if any(p in h for p in ["admin", "operator", "owner"]) and "out of scope" in h:
+            return 4
+        if "known" in h and ("documented" in h or "acknowledged" in h):
+            return 5
+        if "simulation" in h and "custom" in h:
+            return 6
+        return None
+
+
+def register(bus):
+    agent = NexusTrinityAgent()
+    bus.register(agent, subscriptions={"nexus.hypothesis", "nexus.pipeline", "nexus.gate"})
+    print("[plugin] nexus_trinity registered")

--- a/plugins/repl_plugin.py
+++ b/plugins/repl_plugin.py
@@ -9,13 +9,18 @@ class ReplAgent(Agent):
         bus.register_agent(name, self, subscriptions={})
 
     def start(self):
-        import threading
+        import sys, threading
+        if not sys.stdin.isatty():
+            return
         def repl_loop():
             while True:
-                line = input(">> ")
+                try:
+                    line = input(">> ")
+                except (EOFError, KeyboardInterrupt):
+                    break
                 m = new_message("command", line.strip())
                 self.bus.dispatch("command", m)
-        threading.Thread(target=repl_loop, daemon=True).start()
+        threading.Thread(target=repl_loop, daemon=True, name="repl_loop").start()
 
 def register(bus):
     agent = ReplAgent("repl", bus)

--- a/scripts/hp_setup.sh
+++ b/scripts/hp_setup.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# HP setup — run this on the 36GB RAM machine after llama4:scout finishes pulling.
+# Clones the scout Modelfile repo and builds all hardened Ollama models.
+set -euo pipefail
+
+SCOUT_DIR="$HOME/scout"
+REPO="https://github.com/notonelikeme-cmd/scout.git"
+
+echo "=== AetherionGenesis HP Setup ==="
+echo "Host: $(hostname)"
+echo "Date: $(date)"
+echo ""
+
+# ── 1. Clone or update scout Modelfiles ──────────────────────────────────────
+if [ -d "$SCOUT_DIR/.git" ]; then
+  echo "[1/5] Updating scout Modelfiles..."
+  git -C "$SCOUT_DIR" pull
+else
+  echo "[1/5] Cloning scout Modelfiles..."
+  git clone "$REPO" "$SCOUT_DIR"
+fi
+echo "      Scout dir: $SCOUT_DIR"
+echo ""
+
+# ── 2. Verify base models are pulled ─────────────────────────────────────────
+echo "[2/5] Checking base models..."
+REQUIRED_MODELS=("llama4:scout" "qwen2.5-coder:14b" "deepseek-r1:14b" "gemma4:latest")
+MISSING=()
+for model in "${REQUIRED_MODELS[@]}"; do
+  if ollama list | grep -q "^${model%:*}"; then
+    echo "      ✓ $model"
+  else
+    echo "      ✗ $model — MISSING, pulling..."
+    ollama pull "$model"
+    MISSING+=("$model")
+  fi
+done
+echo ""
+
+# ── 3. Build hardened Ollama models ──────────────────────────────────────────
+echo "[3/5] Building hardened models..."
+
+cd "$SCOUT_DIR"
+
+build_model() {
+  local name="$1"
+  local file="$2"
+  if [ -f "$file" ]; then
+    echo "      Building $name from $file..."
+    ollama create "$name" -f "$file" && echo "      ✓ $name" || echo "      ✗ $name FAILED"
+  else
+    echo "      SKIP $name — $file not found"
+  fi
+}
+
+build_model "scout"           "Modelfile"
+build_model "scout-mem"       "Modelfile.mem"
+build_model "scout-pm"        "polymarket/Modelfile.pm"
+build_model "r1-sec"          "Modelfile.r1"
+build_model "gemma4-sec"      "Modelfile.gemma"
+build_model "qwen-sec"        "Modelfile.qwen"
+build_model "scout-llama4"    "Modelfile.scout-llama4"
+echo ""
+
+# ── 4. Clone AetherionGenesis ─────────────────────────────────────────────────
+AETHER_DIR="$HOME/AetherionGenesis"
+AETHER_REPO="https://github.com/notonelikeme-cmd/AetherionGenesis.git"
+
+echo "[4/5] AetherionGenesis..."
+if [ -d "$AETHER_DIR/.git" ]; then
+  echo "      Updating..."
+  git -C "$AETHER_DIR" pull
+else
+  echo "      Cloning..."
+  git clone "$AETHER_REPO" "$AETHER_DIR"
+fi
+
+# Install Python deps
+echo "      Installing Python deps..."
+pip install --quiet networkx numpy watchdog gitpython 2>&1 | tail -1
+# faiss-cpu is large — install separately
+pip install --quiet faiss-cpu 2>&1 | tail -1 || echo "      faiss-cpu skipped (optional)"
+echo "      ✓ deps done"
+echo ""
+
+# ── 5. Smoke test kernel boot ─────────────────────────────────────────────────
+echo "[5/5] Kernel boot smoke test..."
+cd "$AETHER_DIR"
+timeout 10 python3 -c "
+from core.kernel import Kernel
+k = Kernel()
+k.bootstrap()
+" && echo "      ✓ kernel boots clean" || echo "      ✗ kernel boot failed — check output above"
+
+echo ""
+echo "=== HP Setup Complete ==="
+echo "Registered models:"
+ollama list | grep -E "scout|r1-sec|gemma4-sec|qwen-sec"
+echo ""
+echo "To run the kernel as a service:"
+echo "  cd ~/AetherionGenesis && python3 -m core.kernel"
+echo ""
+echo "To dispatch a pipeline from Python:"
+echo "  from core.kernel import Kernel"
+echo "  k = Kernel()"
+echo "  k.bootstrap()   # in a thread"
+echo "  k.dispatch('nexus.pipeline', {'hypothesis': '...', 'contract_path': '...', 'code': '...'})"


### PR DESCRIPTION
- Default non-interactive mode returns immediately after bootstrap
  (plugins loaded, agents registered, kernel ready to dispatch)
- Long-running service mode requires explicit AETHER_SERVICE=1 env var
- Removes the blocking _stop.wait() from the default path so tests,
  imports, and programmatic use don't hang.

## Summary by Sourcery

Adjust kernel bootstrap behavior to exit immediately in non-interactive mode while adding service-mode support and new LLM integration plugins.

New Features:
- Introduce explicit service mode via AETHER_SERVICE for long-running kernel operation with signal-based shutdown.
- Add Nexus Trinity plugin implementing a 7-gate vulnerability verification pipeline integrated with an external model router.
- Add AgentAI bridge plugin exposing the external model router as a bus-addressable LLM completion service.
- Expose a Kernel.dispatch convenience method for programmatic message dispatch to agents.
- Add core heartbeat, logging, scheduler, and perception agents as named agent stubs.
- Add a scheduler and REPL plugin safeguards for non-interactive environments.

Bug Fixes:
- Ensure non-interactive kernel bootstrap returns without blocking so imports, tests, and scripts do not hang.
- Guard consensus startup when raftos is not installed and adjust configuration to avoid runtime failures.
- Prevent REPL plugin from starting in non-interactive contexts and handle EOF/interrupts cleanly.
- Harden plugin loading to resolve the plugins directory robustly and skip failing plugins without crashing the kernel.
- Improve agent bus dispatch robustness by catching agent handler errors and unimplemented handlers per message.

Enhancements:
- Refine kernel bootstrap flow to load plugins synchronously, register signal handlers, and conditionally start the REPL based on TTY presence.
- Simplify consensus node construction and keep naming compatible while making configuration more self-contained.
- Modernize EchoAgent to use the generic handle(message_type, payload) interface and simple echo behavior.
- Add a convenience AgentBus.register method that uses the agent's name attribute for registration.

Build:
- Add hp_setup.sh script to automate high-performance host setup, including pulling base Ollama models, building hardened model variants, installing Python dependencies, and smoke-testing kernel boot.

Tests:
- Add a kernel smoke test step in the hp_setup.sh script to validate clean bootstrap in the new non-interactive mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added agent support for pulse, logging, perception, scheduling, and model-completion workflows.
  - Added asynchronous AI completion requests with success and error responses.
  - Added a seven-stage vulnerability verification pipeline with findings and rejection results.
  - Added optional consensus operation when the consensus service is unavailable.
  - Added improved plugin discovery and fault isolation.

- **Bug Fixes**
  - Improved non-interactive operation, signal-based shutdown, and clean REPL exits.
  - Prevented individual agent or plugin errors from interrupting message delivery.

- **Chores**
  - Added a setup script for models, dependencies, and kernel smoke testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->